### PR TITLE
feat: 공통 응답 포맷 개발

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -24,6 +24,10 @@ dependencies {
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+    // Lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/common/src/main/java/com/msa/common/response/ApiResponse.java
+++ b/common/src/main/java/com/msa/common/response/ApiResponse.java
@@ -1,0 +1,75 @@
+package com.msa.common.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ApiResponse<T> {
+    private final String status;
+    private final String code;
+    private final String message;
+    private final T data;
+    private final T errors;
+
+    @Builder
+    private ApiResponse(String status, String code, String message, T data, T errors) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+        this.data = data;
+        this.errors = errors;
+    }
+
+    // 성공 응답
+    public static <T> ApiResponse<T> success(String message, T data) {
+        return createApiResponse(ResponseStatus.SUCCESS.toString(), "S200", message, data, null);
+    }
+
+    public static <T> ApiResponse<T> success(T data) {
+        return createApiResponse(ResponseStatus.SUCCESS.toString(), "S200", "OK", data, null);
+    }
+
+    public static ApiResponse<Void> success(String message) {
+        return createApiResponse(ResponseStatus.SUCCESS.toString(), "S200", message, null, null);
+    }
+
+    public static ApiResponse<Void> success() {
+        return createApiResponse(ResponseStatus.SUCCESS.toString(), "S200", "OK", null, null);
+    }
+
+    // 실패 응답
+    public static <T> ApiResponse<T> failure(String code, String message, T errors) {
+        return createApiResponse(ResponseStatus.FAIL.toString(), code, message, null, errors);
+    }
+
+    public static <T> ApiResponse<T> failure(String code, T errors) {
+        return createApiResponse(ResponseStatus.FAIL.toString(), code, null, null, errors);
+    }
+
+    public static ApiResponse<Void> failure(String code, String message) {
+        return createApiResponse(ResponseStatus.FAIL.toString(), code, message, null, null);
+    }
+
+    private static <T> ApiResponse<T> createApiResponse(String status, String code, String message, T data, T errors) {
+        return ApiResponse.<T>builder()
+            .status(status)
+            .code(code)
+            .message(message)
+            .data(data)
+            .errors(errors)
+            .build();
+    }
+
+    @Override
+    public String toString() {
+        return "ApiResponse{" +
+            "status='" + status + '\'' +
+            ", code='" + code + '\'' +
+            ", message='" + message + '\'' +
+            ", data=" + data +
+            ", errors=" + errors +
+            '}';
+    }
+}

--- a/common/src/main/java/com/msa/common/response/ResponseStatus.java
+++ b/common/src/main/java/com/msa/common/response/ResponseStatus.java
@@ -1,0 +1,12 @@
+package com.msa.common.response;
+
+public enum ResponseStatus {
+    SUCCESS("성공"),
+    FAIL("실패");
+
+    private final String message;
+
+    ResponseStatus(String message) {
+        this.message = message;
+    }
+}


### PR DESCRIPTION
> PR 당 코드의 변경은 300줄이 넘어가지 않도록 노력하기

## 📝 요약
API의 일관성을 유지하기 위해 팀에서 사용할 공통 응답 포맷을 작성

참고
- https://github.com/omniti-labs/jsend
- https://github.com/tkdwls4453/ecommerce-msa-server/discussions/18

## 💁‍♂️ 이슈
성공 응답 코드에는 도메인 정보가 필요없다고 판단하여 코드에 도메인 정보를 뺐습니다.
도메인 정보는 실패 응답 코드에만 존재

ex) SOD200 -> S200

## 🔀 변경사항
성공 응답 코드에는 도메인 정보를 넣지 않는 것으로 변경

## 🔗 이슈번호
#16 
