### PR TITLE
유저 회원가입 기능 완성

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,6 @@
+MYSQL_HOST=localhost
+MYSQL_PORT=3306
+MYSQL_ROOT_PASSWORD=rootpassword
+MYSQL_DATABASE=ecommerce
+MYSQL_USER=mysqluser
+MYSQL_PASSWORD=mysqlpw

--- a/.gitignore
+++ b/.gitignore
@@ -53,9 +53,6 @@ cmake-build-*/
 # File-based project format
 *.iws
 
-# IntelliJ
-out/
-
 # mpeltonen/sbt-idea plugin
 .idea_modules/
 

--- a/.gitignore
+++ b/.gitignore
@@ -224,3 +224,6 @@ gradle-app.setting
 *.hprof
 
 # End of https://www.toptal.com/developers/gitignore/api/java,intellij,macos,windows,gradle
+db/
+
+.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM eclipse-temurin:21-jdk-alpine
+EXPOSE 8080
+ARG JAR_FILE
+COPY ${JAR_FILE} app.jar
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,38 @@
+version: '3'
+services:
+  mysql:
+    image: mysql:8.0
+    networks:
+      - msa_network
+    volumes:
+      - ./db/conf.d:/etc/mysql/conf.d
+      - ./db/data:/var/lib/mysql
+      - ./db/initdb.d:/docker-entrypoint-initdb.d
+    env_file: .env
+    ports:
+      - "3306:3306"
+    environment:
+      - TZ=Asia/Seoul
+      - MYSQL_ROOT_PASSWORD=rootpassword
+      - MYSQL_USER=mysqluser
+      - MYSQL_PASSWORD=mysqlpw
+
+  user-service:
+    image: ecommerce-msa-server-user-service:0.0.1
+    networks:
+      - msa_network
+    ports:
+      - "8081:8080"
+    depends_on:
+      - mysql
+    environment:
+      - SPRING_DATASOURCE_URL=jdbc:mysql://mysql:3306/ecommerce?useSSL=false&allowPublicKeyRetrieval=true
+      - SPRING_DATASOURCE_USERNAME=mysqluser
+      - SPRING_DATASOURCE_PASSWORD=mysqlpw
+      - SPRING_JPA_PROPERTIES_HIBERNATE_DIALECT=org.hibernate.dialect.MySQL8Dialect
+      - SPRING_JPA_HIBERNATE_DDL_AUTO=create-drop
+
+
+networks:
+  msa_network:
+    driver: bridge

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,4 @@
 rootProject.name = 'ecommerce-msa-server'
 include 'common'
+include 'user-service'
 

--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -1,11 +1,12 @@
 plugins {
+    id 'com.palantir.docker' version '0.36.0'
     id 'java'
     id 'org.springframework.boot' version '3.4.1'
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
-group = 'com.msa'
-version = '0.0.1-SNAPSHOT'
+group = 'com.msa.user'
+version = '0.0.1'
 
 java {
     toolchain {
@@ -51,4 +52,12 @@ dependencies {
 
 test {
     useJUnitPlatform()
+}
+
+docker {
+    println(tasks.bootJar.outputs.files)
+    name rootProject.name+'-'+project.name + ":" + version
+    dockerfile file('../Dockerfile')
+    files tasks.bootJar.outputs.files
+    buildArgs(['JAR_FILE': tasks.bootJar.outputs.files.singleFile.name])
 }

--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -32,9 +32,19 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'
 
+    // Jpa
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    // MySQL
+    runtimeOnly 'com.mysql:mysql-connector-j'
+
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    // H2
+    runtimeOnly 'com.h2database:h2'
+
+
 
     implementation project(':common')
 }

--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -28,6 +28,10 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+    // Security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
+
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -1,0 +1,40 @@
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '3.4.1'
+    id 'io.spring.dependency-management' version '1.1.7'
+}
+
+group = 'com.msa'
+version = '0.0.1-SNAPSHOT'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    // Web
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    // Validation
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // Lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    // Test
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    implementation project(':common')
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/user-service/src/main/java/com/msa/user/UserServiceApplication.java
+++ b/user-service/src/main/java/com/msa/user/UserServiceApplication.java
@@ -1,0 +1,13 @@
+package com.msa.user;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
+
+@ComponentScan(basePackages = {"com.msa.common", "com.msa.user"})
+@SpringBootApplication
+public class UserServiceApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(UserServiceApplication.class, args);
+    }
+}

--- a/user-service/src/main/java/com/msa/user/adapter/in/web/UserRegisterController.java
+++ b/user-service/src/main/java/com/msa/user/adapter/in/web/UserRegisterController.java
@@ -1,0 +1,30 @@
+package com.msa.user.adapter.in.web;
+
+import com.msa.common.response.ApiResponse;
+import com.msa.user.adapter.in.web.dto.request.UserRegisterRequest;
+import com.msa.user.application.port.in.UserRegisterCommand;
+import com.msa.user.application.port.in.UserRegisterUseCase;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class UserRegisterController {
+    private final UserRegisterUseCase userRegisterUseCase;
+
+    @PostMapping("/auth/register")
+    public ApiResponse<Void> register(
+        @Valid @RequestBody UserRegisterRequest request
+    ){
+        userRegisterUseCase.register(UserRegisterCommand.builder()
+            .name(request.name())
+            .email(request.email())
+            .password(request.password())
+            .build());
+
+        return ApiResponse.success();
+    }
+}

--- a/user-service/src/main/java/com/msa/user/adapter/in/web/dto/request/UserRegisterRequest.java
+++ b/user-service/src/main/java/com/msa/user/adapter/in/web/dto/request/UserRegisterRequest.java
@@ -1,0 +1,23 @@
+package com.msa.user.adapter.in.web.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+
+@Builder
+public record UserRegisterRequest(
+    @NotEmpty(message = "이름은 필수 입력 값입니다.")
+    @Size(min = 2, max = 50, message = "이름은 2자 이상 50자 이하로 입력해주세요.")
+    String name,
+
+    @NotEmpty(message = "이메일은 필수 입력 값입니다.")
+    @Email(message = "유효한 이메일 형식이 아닙니다.")
+    String email,
+
+    @NotEmpty(message = "비밀번호는 필수 입력 값입니다.")
+    @Size(min = 8, max = 20, message = "비밀번호는 8자 이상 20자 이하로 입력해주세요.")
+    String password
+) {
+
+}

--- a/user-service/src/main/java/com/msa/user/adapter/out/persistence/UserEntity.java
+++ b/user-service/src/main/java/com/msa/user/adapter/out/persistence/UserEntity.java
@@ -1,0 +1,48 @@
+package com.msa.user.adapter.out.persistence;
+
+import com.msa.user.domain.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Table(name = "users")
+public class UserEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 10)
+    private String name;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Builder
+    private UserEntity(Long id, String name, String email, String password) {
+        this.id = id;
+        this.name = name;
+        this.email = email;
+        this.password = password;
+    }
+
+    public User toDomain() {
+        return User.builder()
+            .userId(id)
+            .name(name)
+            .email(email)
+            .password(password)
+            .build();
+    }
+
+}

--- a/user-service/src/main/java/com/msa/user/adapter/out/persistence/UserJpaRepository.java
+++ b/user-service/src/main/java/com/msa/user/adapter/out/persistence/UserJpaRepository.java
@@ -1,0 +1,6 @@
+package com.msa.user.adapter.out.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
+}

--- a/user-service/src/main/java/com/msa/user/adapter/out/persistence/UserJpaRepository.java
+++ b/user-service/src/main/java/com/msa/user/adapter/out/persistence/UserJpaRepository.java
@@ -3,4 +3,6 @@ package com.msa.user.adapter.out.persistence;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
+
+    Boolean existsByEmail(String email);
 }

--- a/user-service/src/main/java/com/msa/user/adapter/out/persistence/UserPersistenceAdapter.java
+++ b/user-service/src/main/java/com/msa/user/adapter/out/persistence/UserPersistenceAdapter.java
@@ -1,0 +1,24 @@
+package com.msa.user.adapter.out.persistence;
+
+import com.msa.user.application.port.out.UserRegisterPort;
+import com.msa.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserPersistenceAdapter implements UserRegisterPort {
+    private final UserJpaRepository userJpaRepository;
+
+    @Override
+    public User save(User user) {
+        UserEntity savedEntity = userJpaRepository.save(UserEntity.builder()
+            .name(user.getName())
+            .email(user.getEmail())
+            .password(user.getPassword())
+            .build());
+
+
+        return savedEntity.toDomain();
+    }
+}

--- a/user-service/src/main/java/com/msa/user/adapter/out/persistence/UserPersistenceAdapter.java
+++ b/user-service/src/main/java/com/msa/user/adapter/out/persistence/UserPersistenceAdapter.java
@@ -21,4 +21,9 @@ public class UserPersistenceAdapter implements UserRegisterPort {
 
         return savedEntity.toDomain();
     }
+
+    @Override
+    public Boolean existsByEmail(String email) {
+        return userJpaRepository.existsByEmail(email);
+    }
 }

--- a/user-service/src/main/java/com/msa/user/application/port/in/UserRegisterCommand.java
+++ b/user-service/src/main/java/com/msa/user/application/port/in/UserRegisterCommand.java
@@ -1,0 +1,12 @@
+package com.msa.user.application.port.in;
+
+import lombok.Builder;
+
+@Builder
+public record UserRegisterCommand(
+    String name,
+    String email,
+    String password
+) {
+
+}

--- a/user-service/src/main/java/com/msa/user/application/port/in/UserRegisterUseCase.java
+++ b/user-service/src/main/java/com/msa/user/application/port/in/UserRegisterUseCase.java
@@ -1,6 +1,8 @@
 package com.msa.user.application.port.in;
 
+import com.msa.user.domain.User;
+
 public interface UserRegisterUseCase {
 
-    void register(UserRegisterCommand userRegisterCommand);
+    User register(UserRegisterCommand userRegisterCommand);
 }

--- a/user-service/src/main/java/com/msa/user/application/port/in/UserRegisterUseCase.java
+++ b/user-service/src/main/java/com/msa/user/application/port/in/UserRegisterUseCase.java
@@ -1,0 +1,6 @@
+package com.msa.user.application.port.in;
+
+public interface UserRegisterUseCase {
+
+    void register(UserRegisterCommand userRegisterCommand);
+}

--- a/user-service/src/main/java/com/msa/user/application/port/out/UserRegisterPort.java
+++ b/user-service/src/main/java/com/msa/user/application/port/out/UserRegisterPort.java
@@ -4,4 +4,5 @@ import com.msa.user.domain.User;
 
 public interface UserRegisterPort {
     User save(User user);
+    Boolean existsByEmail(String email);
 }

--- a/user-service/src/main/java/com/msa/user/application/port/out/UserRegisterPort.java
+++ b/user-service/src/main/java/com/msa/user/application/port/out/UserRegisterPort.java
@@ -1,0 +1,7 @@
+package com.msa.user.application.port.out;
+
+import com.msa.user.domain.User;
+
+public interface UserRegisterPort {
+    User save(User user);
+}

--- a/user-service/src/main/java/com/msa/user/application/service/UserAuthService.java
+++ b/user-service/src/main/java/com/msa/user/application/service/UserAuthService.java
@@ -2,12 +2,28 @@ package com.msa.user.application.service;
 
 import com.msa.user.application.port.in.UserRegisterCommand;
 import com.msa.user.application.port.in.UserRegisterUseCase;
+import com.msa.user.application.port.out.UserRegisterPort;
+import com.msa.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class UserAuthService implements UserRegisterUseCase {
+    private final UserRegisterPort userRegisterPort;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
     @Override
-    public void register(UserRegisterCommand userRegisterCommand) {
+    public User register(UserRegisterCommand userRegisterCommand) {
+        String encodedPassword = bCryptPasswordEncoder.encode(userRegisterCommand.password());
+
+        User user = User.builder()
+            .name(userRegisterCommand.name())
+            .password(encodedPassword)
+            .email(userRegisterCommand.email())
+            .build();
+
+        return userRegisterPort.save(user);
     }
 }

--- a/user-service/src/main/java/com/msa/user/application/service/UserAuthService.java
+++ b/user-service/src/main/java/com/msa/user/application/service/UserAuthService.java
@@ -1,0 +1,13 @@
+package com.msa.user.application.service;
+
+import com.msa.user.application.port.in.UserRegisterCommand;
+import com.msa.user.application.port.in.UserRegisterUseCase;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserAuthService implements UserRegisterUseCase {
+
+    @Override
+    public void register(UserRegisterCommand userRegisterCommand) {
+    }
+}

--- a/user-service/src/main/java/com/msa/user/application/service/UserAuthService.java
+++ b/user-service/src/main/java/com/msa/user/application/service/UserAuthService.java
@@ -4,6 +4,7 @@ import com.msa.user.application.port.in.UserRegisterCommand;
 import com.msa.user.application.port.in.UserRegisterUseCase;
 import com.msa.user.application.port.out.UserRegisterPort;
 import com.msa.user.domain.User;
+import com.msa.user.exception.DuplicateEmailException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -17,6 +18,10 @@ public class UserAuthService implements UserRegisterUseCase {
     @Override
     public User register(UserRegisterCommand userRegisterCommand) {
         String encodedPassword = bCryptPasswordEncoder.encode(userRegisterCommand.password());
+
+        if(userRegisterPort.existsByEmail(userRegisterCommand.email())) {
+            throw new DuplicateEmailException();
+        }
 
         User user = User.builder()
             .name(userRegisterCommand.name())

--- a/user-service/src/main/java/com/msa/user/config/SecurityConfig.java
+++ b/user-service/src/main/java/com/msa/user/config/SecurityConfig.java
@@ -1,0 +1,13 @@
+package com.msa.user.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder(){
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/user-service/src/main/java/com/msa/user/config/SecurityConfig.java
+++ b/user-service/src/main/java/com/msa/user/config/SecurityConfig.java
@@ -2,12 +2,31 @@ package com.msa.user.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 public class SecurityConfig {
     @Bean
     public BCryptPasswordEncoder bCryptPasswordEncoder(){
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(AbstractHttpConfigurer::disable)
+            .formLogin(AbstractHttpConfigurer::disable)
+            .httpBasic(AbstractHttpConfigurer::disable)
+            .authorizeHttpRequests((auth) -> auth
+                .requestMatchers("/**").permitAll()
+            )
+            .sessionManagement((session) -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        return http.build();
     }
 }

--- a/user-service/src/main/java/com/msa/user/domain/User.java
+++ b/user-service/src/main/java/com/msa/user/domain/User.java
@@ -1,0 +1,21 @@
+package com.msa.user.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class User {
+    private Long userId;
+    private String name;
+    private String password;
+    private String email;
+
+    @Builder
+    private User(String name, String password, String email) {
+        this.name = name;
+        this.password = password;
+        this.email = email;
+    }
+
+
+}

--- a/user-service/src/main/java/com/msa/user/domain/User.java
+++ b/user-service/src/main/java/com/msa/user/domain/User.java
@@ -11,11 +11,10 @@ public class User {
     private String email;
 
     @Builder
-    private User(String name, String password, String email) {
+    private User(Long userId, String name, String password, String email) {
+        this.userId = userId;
         this.name = name;
         this.password = password;
         this.email = email;
     }
-
-
 }

--- a/user-service/src/main/java/com/msa/user/exception/DuplicateEmailException.java
+++ b/user-service/src/main/java/com/msa/user/exception/DuplicateEmailException.java
@@ -1,0 +1,9 @@
+package com.msa.user.exception;
+
+import com.msa.common.exception.CustomException;
+
+public class DuplicateEmailException extends CustomException {
+    public DuplicateEmailException() {
+        super(UserErrorCode.DUPLICATE_EMAIL_ERROR);
+    }
+}

--- a/user-service/src/main/java/com/msa/user/exception/UserErrorCode.java
+++ b/user-service/src/main/java/com/msa/user/exception/UserErrorCode.java
@@ -1,0 +1,16 @@
+package com.msa.user.exception;
+
+import com.msa.common.response.StatusCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserErrorCode implements StatusCode {
+    DUPLICATE_EMAIL_ERROR(HttpStatus.BAD_REQUEST, "FUS400", "중복된 이메일입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/user-service/src/test/java/com/msa/user/adapter/in/web/UserRegisterControllerTest.java
+++ b/user-service/src/test/java/com/msa/user/adapter/in/web/UserRegisterControllerTest.java
@@ -1,0 +1,114 @@
+package com.msa.user.adapter.in.web;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.msa.user.adapter.in.web.dto.request.UserRegisterRequest;
+import com.msa.user.application.port.in.UserRegisterCommand;
+import com.msa.user.application.port.in.UserRegisterUseCase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(UserRegisterController.class)
+class UserRegisterControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private UserRegisterUseCase userRegisterUseCase;
+
+    @Nested
+    @DisplayName("POST /auth/register")
+    class Register{
+        private final String name = "testname";
+        private final String email = "test123@naver.com";
+        private final String password = "testpassword123";
+
+        @Test
+        @DisplayName("회원 가입 정보로 유저 정보를 생성한다. 200 OK")
+        void testRegister_200OK() throws Exception {
+            // Given
+            UserRegisterRequest request = UserRegisterRequest.builder()
+                .name(name)
+                .email(email)
+                .password(password)
+                .build();
+
+            String body = objectMapper.writeValueAsString(request);
+
+            willDoNothing().given(userRegisterUseCase)
+                .register(any(UserRegisterCommand.class));
+
+            // When Then
+            mockMvc.perform(
+                    post("/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body)
+                )
+                .andDo(print())
+                .andExpect(
+                    status().isOk()
+                );
+
+            verify(userRegisterUseCase, times(1))
+                .register(any(UserRegisterCommand.class));
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+            "'',test123@naver.com, testpassword123", // 이름 null
+            "a,test123@naver.com, testpassword123", // 이름 1글자
+            "testname, '', testpassword123", // 이메일 null
+            "testname, test123, testpassword123", // 이메일 형식 X
+            "testname, test123@naver.com, ''", // 비밀번호 null
+            "testname, test123@naver.com, 1234", // 비밀번호 길이 8 미만
+        })
+        @DisplayName("유효하지 않은 정보로 가입 시도 시 실패한다. 400 BAD_REQUEST")
+        void testRegister_400_BAD_REQUEST(String name, String email, String password) throws Exception {
+            // Given
+            UserRegisterRequest request = UserRegisterRequest.builder()
+                .name(name)
+                .email(email)
+                .password(password)
+                .build();
+
+            String body = objectMapper.writeValueAsString(request);
+
+            willDoNothing().given(userRegisterUseCase)
+                .register(any(UserRegisterCommand.class));
+
+            // When Then
+            mockMvc.perform(
+                    post("/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value("FAIL"))
+                .andExpect(jsonPath("$.code").value("F400"));
+
+
+            verify(userRegisterUseCase, times(0))
+                .register(any(UserRegisterCommand.class));
+        }
+    }
+
+}

--- a/user-service/src/test/java/com/msa/user/adapter/in/web/UserRegisterControllerTest.java
+++ b/user-service/src/test/java/com/msa/user/adapter/in/web/UserRegisterControllerTest.java
@@ -13,7 +13,6 @@ import com.msa.user.adapter.in.web.dto.request.UserRegisterRequest;
 import com.msa.user.application.port.in.UserRegisterCommand;
 import com.msa.user.application.port.in.UserRegisterUseCase;
 import com.msa.user.application.port.out.UserRegisterPort;
-import com.msa.user.config.SecurityConfig;
 import com.msa.user.domain.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;

--- a/user-service/src/test/java/com/msa/user/adapter/in/web/UserRegisterControllerTest.java
+++ b/user-service/src/test/java/com/msa/user/adapter/in/web/UserRegisterControllerTest.java
@@ -2,6 +2,7 @@ package com.msa.user.adapter.in.web;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -11,6 +12,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.msa.user.adapter.in.web.dto.request.UserRegisterRequest;
 import com.msa.user.application.port.in.UserRegisterCommand;
 import com.msa.user.application.port.in.UserRegisterUseCase;
+import com.msa.user.application.port.out.UserRegisterPort;
+import com.msa.user.config.SecurityConfig;
+import com.msa.user.domain.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -34,6 +38,9 @@ class UserRegisterControllerTest {
     @MockitoBean
     private UserRegisterUseCase userRegisterUseCase;
 
+    @MockitoBean
+    private UserRegisterPort userRegisterPort;
+
     @Nested
     @DisplayName("POST /auth/register")
     class Register{
@@ -53,14 +60,15 @@ class UserRegisterControllerTest {
 
             String body = objectMapper.writeValueAsString(request);
 
-            willDoNothing().given(userRegisterUseCase)
-                .register(any(UserRegisterCommand.class));
+            when(userRegisterUseCase.register(any(UserRegisterCommand.class)))
+                .thenReturn(any(User.class));
 
             // When Then
             mockMvc.perform(
                     post("/auth/register")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body)
+                        .with(csrf())
                 )
                 .andDo(print())
                 .andExpect(
@@ -90,9 +98,6 @@ class UserRegisterControllerTest {
                 .build();
 
             String body = objectMapper.writeValueAsString(request);
-
-            willDoNothing().given(userRegisterUseCase)
-                .register(any(UserRegisterCommand.class));
 
             // When Then
             mockMvc.perform(

--- a/user-service/src/test/java/com/msa/user/adapter/out/persistence/UserPersistenceAdapterTest.java
+++ b/user-service/src/test/java/com/msa/user/adapter/out/persistence/UserPersistenceAdapterTest.java
@@ -1,0 +1,47 @@
+package com.msa.user.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.msa.user.domain.User;
+import com.msa.user.domain.UserFixtures;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UserPersistenceAdapterTest {
+
+    @InjectMocks
+    private UserPersistenceAdapter sut;
+
+    @Mock
+    private UserJpaRepository userJpaRepository;
+
+    @Test
+    @DisplayName("유저 도메인을 엔티티로 변경하여 저장한다.")
+    void shouldChangeToEntityAndSave(){
+        // Given
+        User user = UserFixtures.user();
+        UserEntity savedUserEntity = UserFixtures.userEntity(1L, user);
+
+        when(userJpaRepository.save(any(UserEntity.class))).thenReturn(savedUserEntity);
+
+        // When
+        User savedUser = sut.save(user);
+
+        // Then
+        assertThat(savedUser).isNotNull();
+        assertThat(savedUser.getUserId()).isEqualTo(1L);
+        assertThat(savedUser.getName()).isEqualTo(user.getName());
+        assertThat(savedUser.getEmail()).isEqualTo(user.getEmail());
+        assertThat(savedUser.getPassword()).isEqualTo(user.getPassword());
+
+        verify(userJpaRepository).save(any(UserEntity.class));
+    }
+}

--- a/user-service/src/test/java/com/msa/user/application/service/UserAuthServiceTest.java
+++ b/user-service/src/test/java/com/msa/user/application/service/UserAuthServiceTest.java
@@ -1,0 +1,69 @@
+package com.msa.user.application.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.msa.user.application.port.in.UserRegisterCommand;
+import com.msa.user.application.port.out.UserRegisterPort;
+import com.msa.user.domain.User;
+import com.msa.user.domain.UserFixtures;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+/**
+ * register(userRegisterCommand)
+ *  - 유저 정보로 도메인을 생성한다.
+ *  - 도메인 생성 시, 패스워드를 암호화 한다.
+ *  - 유저 도메인을 데이터베이스에 저장한다.
+ */
+@ExtendWith(MockitoExtension.class)
+class UserAuthServiceTest {
+
+    @InjectMocks
+    private UserAuthService sut;
+
+    @Mock
+    private BCryptPasswordEncoder bCryptPasswordEncoder;
+
+    @Mock
+    private UserRegisterPort userRegisterPort;
+
+
+    @DisplayName("[service] 회원가입 로직 테스트")
+    @Nested
+    class register{
+
+        @Test
+        @DisplayName("회원가입 성공 시 암호화된 비밀번호로 유저를 생성")
+        void shouldEncryptPasswordAndCreateUser() {
+            // Given
+            UserRegisterCommand command = UserFixtures.registerUserCommand();
+
+            String encryptedPassword = "encryptedPassword";
+            User savedUser = UserFixtures.user(command.name(), command.email(), encryptedPassword);
+
+            when(bCryptPasswordEncoder.encode(command.password())).thenReturn(encryptedPassword);
+            when(userRegisterPort.save(any(User.class))).thenReturn(savedUser);
+
+            // When
+            User result = sut.register(command);
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.getName()).isEqualTo(savedUser.getName());
+            assertThat(result.getEmail()).isEqualTo(savedUser.getEmail());
+            assertThat(result.getPassword()).isEqualTo(savedUser.getPassword());
+
+            verify(userRegisterPort).save(any(User.class));
+            verify(bCryptPasswordEncoder).encode(command.password());
+        }
+    }
+}

--- a/user-service/src/test/java/com/msa/user/domain/UserFixtures.java
+++ b/user-service/src/test/java/com/msa/user/domain/UserFixtures.java
@@ -1,5 +1,6 @@
 package com.msa.user.domain;
 
+import com.msa.user.adapter.out.persistence.UserEntity;
 import com.msa.user.application.port.in.UserRegisterCommand;
 
 public class UserFixtures {
@@ -11,11 +12,28 @@ public class UserFixtures {
             .build();
     }
 
+    public static User user(){
+        return User.builder()
+            .name("testName")
+            .email("test123@naver.com")
+            .password("testPassword")
+            .build();
+    }
+
     public static UserRegisterCommand registerUserCommand() {
         return UserRegisterCommand.builder()
             .name("testName")
             .email("test123@naver.com")
             .password("testPassword")
+            .build();
+    }
+
+    public static UserEntity userEntity(Long id, User user) {
+        return UserEntity.builder()
+            .id(id)
+            .name(user.getName())
+            .email(user.getEmail())
+            .password(user.getPassword())
             .build();
     }
 }

--- a/user-service/src/test/java/com/msa/user/domain/UserFixtures.java
+++ b/user-service/src/test/java/com/msa/user/domain/UserFixtures.java
@@ -1,0 +1,21 @@
+package com.msa.user.domain;
+
+import com.msa.user.application.port.in.UserRegisterCommand;
+
+public class UserFixtures {
+    public static User user(String name, String email, String encryptedPassword ){
+        return User.builder()
+            .name(name)
+            .email(email)
+            .password(encryptedPassword)
+            .build();
+    }
+
+    public static UserRegisterCommand registerUserCommand() {
+        return UserRegisterCommand.builder()
+            .name("testName")
+            .email("test123@naver.com")
+            .password("testPassword")
+            .build();
+    }
+}


### PR DESCRIPTION
> PR 당 코드의 변경은 300줄이 넘어가지 않도록 노력하기

## 📝 요약

회원가입 정보를 받아 이메일 중복 검증 후 유저를 생성하여 저장한다.

## 💁‍♂️ 이슈
- 도커 이미지 빌드를 편리하게 하기 위해서 id `'com.palantir.docker' version '0.36.0'` 플러그인을 사용했습니다.
- Dockerfile은 루트에 하나만 두고 모든 서비스가 공유하는 방식을 사용
- 이미지 빌드 및 도커 컴포즈 실행 명령어
```
./gradlew docker
docker compose up -d
```

## 🔀 변경사항
* [x] 회원가입 테스트 코드 작성
* [x] 회원가입 기능 완성

## 🔗 이슈번호
#25
