### PR TITLE
feat : RedisParsingException 추가 및 핸들링

### DIFF
--- a/common/src/main/java/com/msa/common/exception/GlobalExceptionHandler.java
+++ b/common/src/main/java/com/msa/common/exception/GlobalExceptionHandler.java
@@ -35,6 +35,19 @@ public class GlobalExceptionHandler {
             .body(ApiResponse.failure(errors));
     }
 
+    @ExceptionHandler(value = RedisParsingException.class)
+    public ResponseEntity<ApiResponse<Void>> handleRedisParsingException(RedisParsingException e) {
+
+        log.warn("Failed to parse Redis value. StringValue: '{}', Target Class Fields: '{}', Error Message: '{}'",
+                e.getValue(),
+                e.getClazz().getFields(),
+                e.getMessage());
+
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.error());
+    }
+
     @ExceptionHandler(value = RuntimeException.class)
     public ResponseEntity<ApiResponse<Void>> handleRuntimeException(RuntimeException e) {
 

--- a/common/src/main/java/com/msa/common/exception/RedisParsingException.java
+++ b/common/src/main/java/com/msa/common/exception/RedisParsingException.java
@@ -1,0 +1,25 @@
+package com.msa.common.exception;
+
+import com.msa.common.response.GlobalStatusCode;
+import lombok.Getter;
+
+@Getter
+public class RedisParsingException extends CustomException {
+
+    private final String message;
+    private String value;
+    private Class<?> clazz;
+
+    public RedisParsingException(Exception e) {
+        super(GlobalStatusCode.REDIS_PARSING_ERROR);
+        this.message = e.getMessage();
+    }
+
+    public<T> RedisParsingException(Exception e, String value, Class<T> clazz) {
+        super(GlobalStatusCode.REDIS_PARSING_ERROR);
+        this.message = e.getMessage();
+        this.value = value;
+        this.clazz = clazz;
+    }
+
+}

--- a/common/src/main/java/com/msa/common/redis/JsonValueRedisTemplate.java
+++ b/common/src/main/java/com/msa/common/redis/JsonValueRedisTemplate.java
@@ -2,6 +2,7 @@ package com.msa.common.redis;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.msa.common.exception.RedisParsingException;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 
@@ -100,7 +101,7 @@ public class JsonValueRedisTemplate {
         try {
             return mapper.writeValueAsString(value);
         } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
+            throw new RedisParsingException(e);
         }
     }
 
@@ -108,7 +109,7 @@ public class JsonValueRedisTemplate {
         try {
             return mapper.readValue(stringValue, clazz);
         } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
+            throw new RedisParsingException(e, stringValue, clazz);
         }
     }
 }

--- a/common/src/main/java/com/msa/common/response/GlobalStatusCode.java
+++ b/common/src/main/java/com/msa/common/response/GlobalStatusCode.java
@@ -10,7 +10,8 @@ public enum GlobalStatusCode implements StatusCode {
 
     SUCCESS(HttpStatus.OK, "S200", "성공"),
     FAIL(HttpStatus.BAD_REQUEST, "F400", "잘못된 사용자 요청"),
-    ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E500", "서버 내부 에러");
+    ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E500", "서버 내부 에러"),
+    REDIS_PARSING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "R500", "서버 내부 에러");
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
> PR 당 코드의 변경은 300줄이 넘어가지 않도록 노력하기

## 📝 요약

Redis 데이터 파싱 시 발생하는 JsonParsingException을 핸들링하기 위해
커스텀 예외인 RedisParsingException을 선언했습니다.

들어온 문자열 값의 내용과 변환을 시도했던 클래스의 필드값을 통해 어떤 값이 매칭 되지 않았는지 확인할 수 있습니다.

## 💁‍♂️ 이슈

로그 스태쉬를 쓰지 않으면 JSON 형태로 저장하기 힘든 문제가 있습니다.
추후 ELK를 적용한다면 이를 변경해야 합니다.

## 🔀 변경사항

(진행중 발생한 변경사항이 있다면 작성해주세요)

## 🔗 이슈번호

#33 
